### PR TITLE
Move CommonCrypto header includes into .m file to allow for building …

### DIFF
--- a/Hawk/CryptoProxy.h
+++ b/Hawk/CryptoProxy.h
@@ -9,10 +9,6 @@
 
 #import <Foundation/Foundation.h>
 
-#import <CommonCrypto/CommonDigest.h>
-#import <CommonCrypto/CommonHMAC.h>
-#import <CommonCrypto/CommonCryptor.h>
-
 typedef NS_ENUM(NSUInteger, CryptoAlgorithm) {
     CryptoAlgorithmSHA1,
     CryptoAlgorithmSHA224,

--- a/Hawk/CryptoProxy.m
+++ b/Hawk/CryptoProxy.m
@@ -8,6 +8,9 @@
 //
 
 #import "CryptoProxy.h"
+#import <CommonCrypto/CommonDigest.h>
+#import <CommonCrypto/CommonHMAC.h>
+#import <CommonCrypto/CommonCryptor.h>
 
 @implementation CryptoProxy
 


### PR DESCRIPTION
…as framework on iOS

When using hawk-objc with Cocoapods and `use_frameworks!` importing this library into a Swift file results in compilation errors. Moving the CommonCrypto headers to the file in CryptoProxy.m fixes this problem. No changes in functionality, just moving where includes occur.